### PR TITLE
Add google analytics to documentation website

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,6 +95,6 @@
         "build": "jspm build src/argon.ts dist/argon.js --format umd --global-name Argon",
         "browser-sync": "browser-sync  start --server --directory --startPath \"index.html\" --files \"src/**\"",
         "test": "npm run browser-sync",
-        "typedoc": "typedoc --out docs --name argon.js --readme README.md --target ES5 --module commonjs --experimentalDecorators --excludeNotExported --excludeExternals src/argon.ts src/context.ts src/device.ts src/reality.ts src/view.ts src/session.ts src/timer.ts src/utils.ts src/vuforia.ts src/definitions jspm_packages/github/aurelia/dependency-injection@0.12.1/aurelia-dependency-injection.d.ts jspm_packages/github/aurelia/logging@0.9.0/aurelia-logging.d.ts jspm_packages/github/aurelia/metadata@0.10.1/aurelia-metadata.d.ts jspm_packages/github/aurelia/pal@0.3.0/aurelia-pal.d.ts typings/tsd.d.ts"
+        "typedoc": "typedoc --out docs --gaID UA-63191442-2 --name argon.js --readme README.md --target ES5 --module commonjs --experimentalDecorators --excludeNotExported --excludeExternals src/argon.ts src/context.ts src/device.ts src/reality.ts src/view.ts src/session.ts src/timer.ts src/utils.ts src/vuforia.ts src/definitions jspm_packages/github/aurelia/dependency-injection@0.12.1/aurelia-dependency-injection.d.ts jspm_packages/github/aurelia/logging@0.9.0/aurelia-logging.d.ts jspm_packages/github/aurelia/metadata@0.10.1/aurelia-metadata.d.ts jspm_packages/github/aurelia/pal@0.3.0/aurelia-pal.d.ts typings/tsd.d.ts"
     }
 }


### PR DESCRIPTION
I'm not sure if the code that this generates is correct, since it differs from the one included in the argonjs.io site:

The google analytics code inserted into the documentation website with these changes:

``` js
<script>
  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');

  ga('create', 'UA-63191442-2', 'auto');
  ga('send', 'pageview');
</script>
```

The google analytics code present in the argonjs.io site:

``` js
<script type="text/javascript">
  var _gaq = _gaq || [];
  _gaq.push(['_setAccount', 'UA-63191442-2']);
  _gaq.push(['_trackPageview']);

  (function() {
    var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
    ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
    var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
  })();
</script>
```

If the code being used by the documentation website is not correct I can modify the template we use such that it uses the code present in the argonjs.io site.
